### PR TITLE
Restore target group port to 80

### DIFF
--- a/ops/modules/load_balancer/main.tf
+++ b/ops/modules/load_balancer/main.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "load_balancer" {
-  name            = "${var.project_name}-lb"
+  name            = "${var.project_name}-${var.environment_name}-lb"
   security_groups = [aws_security_group.load_balancer_sg.id, var.default_security_group_id]
   subnets         = var.public_subnet_ids
 
@@ -7,10 +7,10 @@ resource "aws_lb" "load_balancer" {
 }
 
 resource "aws_lb_target_group" "load_balancer_tg" {
-  name        = "${var.project_name}-lb-tg"
+  name        = "${var.project_name}-${var.environment_name}-lb-tg"
   target_type = "instance"
-  port        = 443
-  protocol    = "HTTPS"
+  port        = 80
+  protocol    = "HTTP"
   vpc_id      = var.vpc_id
 
   health_check {

--- a/ops/modules/load_balancer/variables.tf
+++ b/ops/modules/load_balancer/variables.tf
@@ -1,4 +1,5 @@
 variable "project_name" {}
+variable "environment_name" {}
 variable "vpc_id" {}
 variable "default_security_group_id" {}
 variable "public_subnet_ids" {}

--- a/ops/staging/main.tf
+++ b/ops/staging/main.tf
@@ -41,6 +41,7 @@ module "load_balancer" {
   source = "../modules/load_balancer"
 
   project_name              = var.project_name
+  environment_name          = var.environment_name
   vpc_id                    = module.vpc.vpc_id
   public_subnet_ids         = module.vpc.public_subnet_ids
   default_security_group_id = module.vpc.default_security_group_id


### PR DESCRIPTION
The EC2 instances should still be contacted with HTTP traffic over port 80. The SSL should terminate at the Load balancer for proper offloading.