### PR TITLE
Prepare for paperclip data migration

### DIFF
--- a/db/migrate/20220616234453_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20220616234453_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_24_080820) do
+ActiveRecord::Schema.define(version: 2022_06_16_234453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "attachments", force: :cascade do |t|
     t.integer "course_id"
@@ -188,4 +209,5 @@ ActiveRecord::Schema.define(version: 2021_09_24_080820) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end

--- a/lib/tasks/migrate_paperclip_data.rake
+++ b/lib/tasks/migrate_paperclip_data.rake
@@ -1,0 +1,145 @@
+require 'open-uri'
+
+namespace :migrate_paperclip do
+  desc 'Migrate the paperclip data'
+  task move_data: :environment do
+    # Prepare the insert statements
+    prepare_statements
+
+    # Eager load the application so that all Models are available
+    Rails.application.eager_load!
+
+    # Get a list of all the models in the application
+    models = ActiveRecord::Base.descendants.reject(&:abstract_class?)
+
+    # Loop through all the models found
+    models.each do |model|
+      puts 'Checking Model [' + model.to_s + '] for Paperclip attachment columns ...'
+
+      # If the model has a column or columns named *_file_name,
+      # We are assuming this is a column added by Paperclip.
+      # Store the name of the attachment(s) found (e.g. "avatar") in an array named attachments
+      attachments = model.column_names.map do |c|
+        Regexp.last_match(1) if c =~ /(.+)_file_name$/
+      end.compact
+
+      # If no Paperclip columns were found in this model, go to the next model
+      if attachments.blank?
+        puts '  No Paperclip attachment columns found for [' + model.to_s + '].'
+        puts ''
+        next
+      end
+
+      puts '  Paperclip attachment columns found for [' + model.to_s + ']: ' + attachments.to_s
+
+      # Loop through the records of the model, and then through each attachment definition within the model
+      model.find_each.each do |instance|
+        attachments.each do |attachment|
+          # If the model record doesn't have an uploaded attachment, skip to the next record
+          next if instance.send(attachment).path.blank?
+
+          # Otherwise, we will convert the Paperclip data to ActiveStorage records
+          create_active_storage_records(instance, attachment, model)
+        end
+      end
+      puts ''
+    end
+  end
+end
+
+private
+
+def prepare_statements
+  # Get the id of the last record inserted into active_storage_blobs
+  # This will be used in the insert to active_storage_attachments
+  # Postgres
+  get_blob_id = 'LASTVAL()'
+  # mariadb
+  # get_blob_id = 'LAST_INSERT_ID()'
+  # sqlite
+  # get_blob_id = 'LAST_INSERT_ROWID()'
+
+  # Prepare two insert statements for the new ActiveStorage tables
+  ActiveRecord::Base.connection.raw_connection.prepare('active_storage_blob_statement', <<-SQL)
+    INSERT INTO active_storage_blobs (
+      key, filename, content_type, metadata, byte_size, checksum, created_at
+    ) VALUES ($1, $2, $3, '{}', $4, $5, $6)
+  SQL
+
+  ActiveRecord::Base.connection.raw_connection.prepare('active_storage_attachment_statement', <<-SQL)
+    INSERT INTO active_storage_attachments (
+      name, record_type, record_id, blob_id, created_at
+    ) VALUES ($1, $2, $3, #{get_blob_id}, $4)
+  SQL
+end
+
+def create_active_storage_records(instance, attachment, model)
+  puts '    Creating ActiveStorage records for [' +
+       model.name + ' (ID: ' + instance.id.to_s + ')] ' +
+       instance.send("#{attachment}_file_name") +
+       ' (' + instance.send("#{attachment}_content_type") + ')'
+
+  build_active_storage_blob(instance, attachment)
+  build_active_storage_attachment(instance, attachment, model)
+end
+
+def build_active_storage_blob(instance, attachment)
+  # Set the values for the new ActiveStorage records based on the data from Paperclip's fields
+  # for active_storage_blobs
+  created_at = instance.updated_at.iso8601
+  blob_key = key(instance, attachment)
+  filename = instance.send("#{attachment}_file_name")
+  content_type = instance.send("#{attachment}_content_type")
+  file_size = instance.send("#{attachment}_file_size")
+  file_checksum = checksum(instance.send(attachment))
+
+  blob_values = [blob_key, filename, content_type, file_size, file_checksum, created_at]
+
+  # Insert the converted blob record into active_storage_blobs
+  insert_record('active_storage_blob_statement', blob_values)
+end
+
+def build_active_storage_attachment(instance, attachment, model)
+  # Set the values for the new ActiveStorage records based on the data from Paperclip's fields
+  # for active_storage_attachments
+  created_at = instance.updated_at.iso8601
+  blob_name = attachment
+  record_type = model.name
+  record_id = instance.id
+
+  attachment_values = [blob_name, record_type, record_id, created_at]
+
+  # Insert the converted attachment record into active_storage_attachments
+  insert_record('active_storage_attachment_statement', attachment_values)
+end
+
+def insert_record(statement, values)
+  ActiveRecord::Base.connection.raw_connection.exec_prepared(
+    statement,
+    values
+  )
+end
+
+def key(_instance, _attachment)
+  # Get a new key
+  SecureRandom.uuid
+  # Alternatively:
+  # instance.send("#{attachment}").path
+end
+
+def checksum(attachment)
+  # Get a checksum for the file (required for ActiveStorage)
+
+  # local files stored on disk:
+  # url = "#{Rails.root}/public/#{attachment.path}"
+  # Digest::MD5.base64digest(File.read(url))
+
+  # remote files stored on a cloud service:
+  url = attachment.url
+
+  if url =~ /^\/{2}s3/
+    url = "https:#{url}"
+  end
+
+  Digest::MD5.base64digest(Net::HTTP.get(URI(url)))
+end


### PR DESCRIPTION
- Adds ActiveStorage models
- Adds `migrate_paperclip:move_data` rake task to copy Paperclip data into ActiveStorage tables