### PR TITLE
Whitelist target in CourseMaterial description links

### DIFF
--- a/app/views/course_materials/show.html.erb
+++ b/app/views/course_materials/show.html.erb
@@ -43,7 +43,7 @@
 </div>
 
 <div class="extra-margin-bottom">
-  <p><%= sanitize @course_material.description %></p>
+  <p><%= sanitize @course_material.description, attributes: %w(href target) %></p>
 </div>
 
 <hr />


### PR DESCRIPTION
Don't strip target attribute from links in CourseMaterial descriptions