### PR TITLE
Fix early garbage collection in attachment zipper

### DIFF
--- a/app/services/attachment_zipper.rb
+++ b/app/services/attachment_zipper.rb
@@ -5,12 +5,16 @@ class AttachmentZipper
 
   def create_zip(attachment_name)
     archive_tempfile = Tempfile.new("file_archive", "tmp")
-  
+
+    # Avoid premature garbage collection by keeping tempfiles in array
+    s3_tempfiles = []
     ::Zip::File.open(archive_tempfile.path, ::Zip::File::CREATE) do |zipfile|
       @files.each do |file|
         if Rails.application.config.s3_enabled
           s3_tempfile = Tempfile.new("s3_contents", "tmp")
+          s3_tempfiles << s3_tempfile
           s3_tempfile << AttachmentReader.new(file).read_attachment_data(attachment_name)
+          s3_tempfile.close
           zipfile.add(file.send("#{attachment_name}_file_name"), s3_tempfile.path)
         else
           zipfile.add(file.send("#{attachment_name}_file_name"), file.send(attachment_name).path)
@@ -18,6 +22,7 @@ class AttachmentZipper
       end
     end
 
+    s3_tempfiles = nil
     open(archive_tempfile)
   end
 end


### PR DESCRIPTION
Store tempfile references in an array to avoid premature garbage collection.